### PR TITLE
feature(API)#170019861:user can delete the redflag/intervention

### DIFF
--- a/server/controllers/recordControllers.js
+++ b/server/controllers/recordControllers.js
@@ -94,6 +94,31 @@ class RecordControllers {
       message: "You can't edit the record it is into investigation",
     });
   }
+
+  // Delete a specific red flag record.
+  static deleteRecord(req, res) {
+    const findRecord = Records.find(
+      (record) => record.id === parseInt(req.params.id, 10),
+    );
+    if (findRecord.status === 'draft') {
+      if (!findRecord) {
+        return res
+          .status(404)
+          .json({ message: 'The record of the given id not found' });
+      }
+      const index = Records.indexOf(findRecord);
+      Records.splice(index, 1);
+      return res.status(200).json({
+        status: res.statusCode,
+        message: 'red-flag record has been deleted',
+        data: findRecord,
+      });
+    }
+    return res.status(400).json({
+      status: res.statusCode,
+      message: "You can't delete this Record",
+    });
+  }
 }
 
 export default RecordControllers;

--- a/server/routes/recordRoutes.js
+++ b/server/routes/recordRoutes.js
@@ -14,5 +14,6 @@ recordRoute.get('/redflags/:id', validation.recordId, recordController.getSingle
 recordRoute.patch('/redflags/:id/location', tokenValidator, validation.recordId, recordController.editLocation);
 // Edit the comment of a specific red-flag record.
 recordRoute.patch('/redflags/:id/comment', tokenValidator, validation.recordId, recordController.editComment);
-
+// Delete a specific red flag record.
+recordRoute.delete('/redflags/:id', tokenValidator, validation.recordId, recordController.deleteRecord);
 export default recordRoute;


### PR DESCRIPTION
#### What does this PR do?
This PR contains endpoint where the user can delete the red-flag
#### Description of Task to be completed?
Have the following endpoint working
 ##### DELETE /api/v1/id/delete
#### How should this be manually tested?
After cloning the repo cd into it and Open terminal and run ###### npm start
   . make sure you have postman installed in order to test this
#### Any background context you want to provide?
in order to delete the redflag you must have a signed token 
#### What are the relevant pivotal tracker stories?
#170019861
#### Screenshots (if appropriate)
![delete](https://user-images.githubusercontent.com/23064036/69828409-c8ac2b00-11e9-11ea-8768-12c6902d4623.png)

#### Questions: